### PR TITLE
Data themes updates

### DIFF
--- a/scripts/orphan_concept.sparql
+++ b/scripts/orphan_concept.sparql
@@ -1,0 +1,22 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT ?c
+WHERE {
+    ?c a skos:Concept .
+
+    MINUS {
+        ?c skos:broader ?x
+    }
+
+    MINUS {
+        ?y skos:narrower ?c .
+    }
+
+    MINUS {
+        ?c skos:topConceptOf ?cs .
+    }
+
+    MINUS {
+        ?cs2 skos:topConceptOf ?c .
+    }
+}

--- a/scripts/skos_hierarchy.py
+++ b/scripts/skos_hierarchy.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+skos_hierarchy.py — Print the concept hierarchy of a SKOS vocabulary file.
+
+Usage:
+    python skos_hierarchy.py <vocab_file> [--lang LANG]
+
+Arguments:
+    vocab_file   Path to the SKOS file (Turtle, RDF/XML, JSON-LD, N-Triples…)
+    --lang       Preferred language tag for labels (default: en)
+
+Example:
+    python skos_hierarchy.py my_thesaurus.ttl
+    python skos_hierarchy.py unesco.rdf --lang fr
+"""
+
+import sys
+import argparse
+from rdflib import Graph, Namespace, URIRef, RDFS
+from rdflib.namespace import SKOS, RDF
+
+# ── ANSI colours (disabled automatically on non-TTY) ─────────────────────────
+USE_COLOR = sys.stdout.isatty()
+
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if USE_COLOR else text
+
+BOLD   = lambda t: _c("1",      t)
+DIM    = lambda t: _c("2",      t)
+CYAN   = lambda t: _c("1;36",   t)
+YELLOW = lambda t: _c("1;33",   t)
+GREEN  = lambda t: _c("32",     t)
+GREY   = lambda t: _c("90",     t)
+
+# ── Label resolution ──────────────────────────────────────────────────────────
+
+def get_label(graph: Graph, uri: URIRef, lang: str) -> str:
+    """Return the best human-readable label for *uri*."""
+    # Priority: prefLabel (target lang) → prefLabel (any) → label → local name
+    candidates = []
+    for pred in (SKOS.prefLabel, SKOS.altLabel, RDFS.label):
+        for obj in graph.objects(uri, pred):
+            obj_str = str(obj)
+            obj_lang = getattr(obj, "language", None)
+            if obj_lang == lang:
+                return obj_str                      # exact language match → done
+            candidates.append((obj_lang, obj_str))
+
+    if candidates:
+        # prefer labels without a language tag, then any
+        for obj_lang, text in candidates:
+            if obj_lang is None:
+                return text
+        return candidates[0][1]
+
+    # Fall back to the local name part of the URI
+    fragment = uri.split("#")[-1] if "#" in uri else uri.split("/")[-1]
+    return fragment or str(uri)
+
+
+# ── Tree builder ──────────────────────────────────────────────────────────────
+
+def build_children(graph: Graph) -> dict:
+    """Return {parent_uri: [child_uri, …]} from skos:narrower / skos:broader."""
+    children: dict = {}
+
+    # Collect all concepts
+    all_concepts = set(graph.subjects(RDF.type, SKOS.Concept))
+    for uri in all_concepts:
+        children.setdefault(uri, [])
+
+    # skos:narrower  (parent → child)
+    for parent, _, child in graph.triples((None, SKOS.narrower, None)):
+        if isinstance(child, URIRef):
+            children.setdefault(parent, [])
+            children[parent].append(child)
+
+    # skos:broader   (child → parent)  — inverse direction
+    for child, _, parent in graph.triples((None, SKOS.broader, None)):
+        if isinstance(parent, URIRef):
+            children.setdefault(parent, [])
+            if child not in children[parent]:
+                children[parent].append(child)
+
+    return children
+
+
+def find_roots(graph: Graph, children: dict) -> list:
+    """
+    Top concepts are those explicitly marked as skos:hasTopConcept / skos:topConceptOf,
+    or concepts with no broader parent at all.
+    """
+    explicit_tops = set()
+    for _, _, tc in graph.triples((None, SKOS.hasTopConcept, None)):
+        explicit_tops.add(tc)
+    for tc, _, _ in graph.triples((None, SKOS.topConceptOf, None)):
+        explicit_tops.add(tc)
+
+    if explicit_tops:
+        return sorted(explicit_tops, key=str)
+
+    # Fallback: concepts that appear as no one's child
+    has_broader = {
+        child
+        for child, _, _ in graph.triples((None, SKOS.broader, None))
+    }
+    all_children = {c for kids in children.values() for c in kids}
+    all_broader  = has_broader | all_children
+    all_concepts = set(graph.subjects(RDF.type, SKOS.Concept))
+    roots = all_concepts - all_broader
+
+    return sorted(roots, key=str)
+
+
+# ── Printer ───────────────────────────────────────────────────────────────────
+
+def print_tree(
+    graph: Graph,
+    children: dict,
+    node: URIRef,
+    lang: str,
+    prefix: str = "",
+    is_last: bool = True,
+    visited: set = None,
+    depth: int = 0,
+) -> None:
+    if visited is None:
+        visited = set()
+
+    connector = "└── " if is_last else "├── "
+    label     = get_label(graph, node, lang)
+    uri_hint  = GREY(f"  <{node}>") if depth == 0 else ""
+
+    # Colour by depth
+    colours = [CYAN, YELLOW, GREEN]
+    coloured_label = colours[min(depth, len(colours) - 1)](label)
+
+    print(f"{prefix}{DIM(connector)}{coloured_label}{uri_hint}")
+
+    if node in visited:
+        # Cycle guard — note it and stop recursing
+        child_prefix = prefix + ("    " if is_last else "│   ")
+        print(f"{child_prefix}{DIM('└── ')}{GREY('(already shown)')}")
+        return
+    visited = visited | {node}
+
+    kids = sorted(children.get(node, []), key=lambda u: get_label(graph, u, lang).lower())
+    for i, kid in enumerate(kids):
+        last = i == len(kids) - 1
+        child_prefix = prefix + ("    " if is_last else "│   ")
+        print_tree(graph, children, kid, lang, child_prefix, last, visited, depth + 1)
+
+
+# ── Scheme metadata ───────────────────────────────────────────────────────────
+
+def print_scheme_info(graph: Graph, lang: str) -> None:
+    schemes = list(graph.subjects(RDF.type, SKOS.ConceptScheme))
+    if not schemes:
+        return
+    print(BOLD("\n  Concept Scheme(s):"))
+    for scheme in schemes:
+        title = get_label(graph, scheme, lang)
+        print(f"  {YELLOW(title)}  {GREY(f'<{scheme}>')}")
+    print()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Print the SKOS concept hierarchy of a vocabulary file."
+    )
+    parser.add_argument("vocab_file", help="Path to the SKOS vocabulary file")
+    parser.add_argument(
+        "--lang", default="en", help="Preferred language for labels (default: en)"
+    )
+    args = parser.parse_args()
+
+    # ── Load graph ────────────────────────────────────────────────────────────
+    g = Graph()
+    try:
+        g.parse(args.vocab_file)
+    except Exception as exc:
+        print(f"ERROR: Could not parse '{args.vocab_file}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    n_concepts = sum(1 for _ in g.subjects(RDF.type, SKOS.Concept))
+    if n_concepts == 0:
+        print("WARNING: No skos:Concept triples found in this file.", file=sys.stderr)
+
+    # ── Summary header ────────────────────────────────────────────────────────
+    print(BOLD(f"\n{'═' * 60}"))
+    print(BOLD(f"  SKOS Concept Hierarchy"))
+    print(BOLD(f"  File : {args.vocab_file}"))
+    print(BOLD(f"  Lang : {args.lang}   |   Concepts: {n_concepts}"))
+    print(BOLD(f"{'═' * 60}"))
+
+    print_scheme_info(g, args.lang)
+
+    # ── Build & print tree ────────────────────────────────────────────────────
+    children = build_children(g)
+    roots    = find_roots(g, children)
+
+    if not roots:
+        print("No top-level concepts found.", file=sys.stderr)
+        sys.exit(1)
+
+    for i, root in enumerate(roots):
+        last = i == len(roots) - 1
+        print_tree(g, children, root, args.lang, prefix="  ", is_last=last)
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skos_hierarchy.py
+++ b/scripts/skos_hierarchy.py
@@ -61,26 +61,37 @@ def get_label(graph: Graph, uri: URIRef, lang: str) -> str:
 # ── Tree builder ──────────────────────────────────────────────────────────────
 
 def build_children(graph: Graph) -> dict:
-    """Return {parent_uri: [child_uri, …]} from skos:narrower / skos:broader."""
-    children: dict = {}
+    """Return {parent_uri: [child_uri, …]} from skos:narrower / skos:broader.
 
-    # Collect all concepts
-    all_concepts = set(graph.subjects(RDF.type, SKOS.Concept))
-    for uri in all_concepts:
-        children.setdefault(uri, [])
+    skos:broader and skos:narrower are inverse properties of each other, so a
+    single parent→child edge can be stated either way (or both).  We normalise
+    every edge to the canonical parent→child direction and deduplicate so that
+    redundant reciprocal declarations don't produce duplicate children.
+    """
+    # Seed every known concept with an empty list
+    children: dict = {
+        uri: []
+        for uri in graph.subjects(RDF.type, SKOS.Concept)
+        if isinstance(uri, URIRef)
+    }
 
-    # skos:narrower  (parent → child)
+    # Use a set of (parent, child) pairs to deduplicate across both properties
+    edges: set = set()
+
+    # skos:narrower  subject=parent, object=child  (parent → child)
     for parent, _, child in graph.triples((None, SKOS.narrower, None)):
-        if isinstance(child, URIRef):
-            children.setdefault(parent, [])
-            children[parent].append(child)
+        if isinstance(parent, URIRef) and isinstance(child, URIRef):
+            edges.add((parent, child))
 
-    # skos:broader   (child → parent)  — inverse direction
+    # skos:broader   subject=child,  object=parent (child → parent, i.e. parent → child inverted)
     for child, _, parent in graph.triples((None, SKOS.broader, None)):
-        if isinstance(parent, URIRef):
-            children.setdefault(parent, [])
-            if child not in children[parent]:
-                children[parent].append(child)
+        if isinstance(parent, URIRef) and isinstance(child, URIRef):
+            edges.add((parent, child))   # normalise to parent→child
+
+    for parent, child in edges:
+        children.setdefault(parent, [])
+        children.setdefault(child, [])
+        children[parent].append(child)
 
     return children
 

--- a/vocabularies/DataThemes.ttl
+++ b/vocabularies/DataThemes.ttl
@@ -59,7 +59,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :data_acquisition
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader :sample_acquisition_and_management ;
     skos:definition "Data acquisition related to the systematic processes of gathering observations and measurements, and related analytical techniques and methodologies, including sample preparation techniques."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "data acquisition"@en ;
@@ -81,11 +80,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :geoinformatics
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
+    skos:broader :information_management ;
     skos:altLabel "geomatics"@en ;
     skos:definition "Geoinformatics is a scientific field primarily within the domains of Computer Science and technical geography. It focuses on the programming of applications, spatial data structures, and the analysis of objects and space-time phenomena related to the surface and underneath of Earth and other celestial bodies. The field develops software and web services to model and analyse spatial data, serving the needs of geosciences and related scientific and engineering disciplines. The term is often used interchangeably with Geomatics, although they are not exactly same. The field of geomatics is a comprehensive discipline encompassing both geodesy and geoinformatics, thus offering a more extensive scope."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "geoinformatics"@en ;
-    skos:topConceptOf cs: ;
     schema:citation "https://en.wikipedia.org/wiki/Geoinformatics"^^xsd:anyURI ;
     schema:status astatus:experimental ;
 .
@@ -130,6 +129,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:inScheme cs: ;
     skos:prefLabel "hydrology"@en ;
     skos:topConceptOf cs: ;
+    skos:narrower :hydrogeology , :hydrogeochemistry ;
     schema:citation "https://www.usgs.gov/water-science-school/science/what-hydrology#Hydrology"^^xsd:anyURI ;
     schema:status astatus:experimental ;
 .
@@ -227,17 +227,27 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:definition "Sample acquisition is related to the collection/procurement, handling, tracking, storing, and retrieving of primary geoscience material (typically, but not exclusively, a rock, mineral, fossil or soil) collected in the field or from materials collected in the field (e.g. drillcore)"@en ;
     skos:inScheme cs: ;
-    skos:narrower :sample_acquisition_and_management ;
+    skos:broader :sample_acquisition_and_management ;
     skos:prefLabel "sample acquisition"@en ;
-    skos:topConceptOf cs: ;
     schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/sample-acquisition-management"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:data_acquisition
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :data_management ;
+    skos:definition "Data acquisition related to the systematic processes of gathering observations and measurements, and related analytical techniques and methodologies, including sample preparation techniques."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "data acquisition"@en ;
+    schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/data-acquisition"^^xsd:anyURI ;
     schema:status astatus:experimental ;
 .
 
 :data_management
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader :sample_acquisition_and_management ;
+    skos:broader :information_management ;
     skos:definition "Data Management is the development, execution, and supervision of plans, policies, programs, and practices that deliver, control, protect, and enhance the value of data and information assets throughout their lifecycles. It encompasses a range of disciplines and processes that collectively enable organizations to derive meaningful insights, make informed decisions, and maintain compliance with regulatory standards."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "data management"@en ;
@@ -264,7 +274,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:inScheme cs: ;
     skos:narrower :hydrogeochemistry ;
     skos:prefLabel "geochemistry"@en ;
-    skos:topConceptOf cs: ;
+    skos:broader :geology ;
     schema:citation "https://glossary.americangeosciences.org/term/geochemistry"^^xsd:anyURI ;
     schema:status astatus:experimental ;
 .
@@ -348,13 +358,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :sample_acquisition_and_management
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader :data_management ;
     skos:definition "Sample acquisition and management is related to the collection/procurement, handling, tracking, storing, and retrieving of primary geoscience material (typically, but not exclusively, a rock, mineral, fossil or soil) collected in the field or from materials collected in the field (e.g. drillcore), as well as derived specimens from such materials for the purpose of analysis and research. Included are vocabularies related to collections as single entities."@en ;
     skos:inScheme cs: ;
-    skos:narrower
-        :data_acquisition ,
-        :sample_acquisition ;
     skos:prefLabel "sample acquisition and management"@en ;
+    skos:narrower :sample_acquisition ;
     schema:citation "https://linked.data.gov.au/def/gswa-vocabulary-themes/sample-acquisition-management"^^xsd:anyURI ;
     schema:status astatus:experimental ;
 .
@@ -379,6 +386,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :geophysics
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
+    skos:broader :geology ;
     skos:definition "Geophysics is the investigation of the solid and molten Earth using physical principles which allow studies on large scales and of the otherwise inaccessible deep Earth. Geophysical methods are used to study large scale Earth Structure, to measure the exact shape and size of the planet (Geodesy), to study the dynamics of the Earth’s interior and tectonic plates (Geodynamics), to study the history of Earth’s magnetic field and its present state (Geomagnetism), to study the physical properties of rocks and minerals at or near the surface, as well as those in the core (Mineral Physics), and finally, to study the physical causes and effects of earthquakes (Seismology)."@en ;
     skos:inScheme cs: ;
     skos:narrower
@@ -388,7 +396,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         :radiometrics ,
         :seismology ;
     skos:prefLabel "geophysics"@en ;
-    skos:topConceptOf cs: ;
     schema:citation "https://www.sciencedirect.com/science/chapter/referencework/pii/B9780124095489053549#s0015"^^xsd:anyURI ;
     schema:status astatus:experimental ;
 .
@@ -399,16 +406,13 @@ cs:
     skos:definition "These geoscience data themes are used by Geoscience Australia to enable sorting of content in their registers."@en ;
     skos:hasTopConcept
         :administration ,
-        :data_management ,
         :earth_observation ,
-        :geochemistry ,
         :geography ,
-        :geoinformatics ,
         :geology ,
-        :geophysics ,
         :hydrology ,
         :information_management ,
-        :legislation ;
+        :legislation ,
+        :sample_acquisition_and_management ;
     skos:historyNote "This vocabulary is a refresh of a previous GA data classification. The definitions have been sourced from other Australian Geological Surveys where possible. This was created for the purpose of grouping related vocabularies and other GA products to enable easy sorting by data type." ;
     skos:prefLabel "GA Register Data Themes"@en ;
     prov:qualifiedAttribution

--- a/vocabularies/SeabedGeomorphologySettings.ttl
+++ b/vocabularies/SeabedGeomorphologySettings.ttl
@@ -12,7 +12,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :aggregation
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader <https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologySettings/> ;
     skos:definition "currently under working group consultation"@en ;
     skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;
@@ -24,7 +23,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :alluvial
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader <https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologySettings/> ;
     skos:definition "currently under working group consultation"@en ;
     skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;
@@ -55,7 +53,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :coastal_fan_delta
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader <https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologySettings/> ;
     skos:definition "currently under working group consultation"@en ;
     skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;
@@ -75,7 +72,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :fluvial_fan_delta
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader <https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologySettings/> ;
     skos:definition "currently under working group consultation"@en ;
     skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;
@@ -87,7 +83,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :sediment_trapped_bound
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader <https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologySettings/> ;
     skos:definition "currently under working group consultation"@en ;
     skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;
@@ -1641,7 +1636,7 @@ Cf. COASTAL PRO-DELTA"""@en ;
     skos:historyNote "2026-05: This Concept was updated in 2026 following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;
     skos:narrower
-        :non_volcanic ,
+        :non-volcanic ,
         :volcanic ;
     skos:prefLabel "guyot"@en ;
     schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/BGU-Type_BGU-T"^^xsd:anyURI ;
@@ -2380,10 +2375,10 @@ Cf. COASTAL PRO-DELTA"""@en ;
     schema:status astatus:stable ;
 .
 
-:non_volcanic
+:non-volcanic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader <https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologySettings/> ;
+    skos:broader :guyot ;
     skos:definition "currently under working group consultation"@en ;
     skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;
@@ -3801,7 +3796,7 @@ Cf. "fan/apron" in Harris et al., (2014), cf. APRON (MORPHOLOGY)."""@en ;
 :volcanic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:broader <https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologySettings/> ;
+    skos:broader :guyot ;
     skos:definition "currently under working group consultation"@en ;
     skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;

--- a/vocabularies/SeabedGeomorphologySettings.ttl
+++ b/vocabularies/SeabedGeomorphologySettings.ttl
@@ -9,88 +9,6 @@ PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-:aggregation
-    a skos:Concept ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "currently under working group consultation"@en ;
-    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
-    skos:inScheme cs: ;
-    skos:prefLabel "aggregation"@en ;
-    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
-    schema:status astatus:experimental ;
-.
-
-:alluvial
-    a skos:Concept ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "currently under working group consultation"@en ;
-    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
-    skos:inScheme cs: ;
-    skos:prefLabel "alluvial"@en ;
-    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/BGU-Type_BGU-T"^^xsd:anyURI ;
-    schema:status astatus:experimental ;
-.
-
-:coastal_delta_lobe
-    a skos:Concept ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "currently under working group consultation"@en ;
-    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
-    skos:inScheme cs: ;
-    skos:narrower
-        :bayhead ,
-        :coastal_delta-front ,
-        :coastal_pro-delta ,
-        :lower ,
-        :shelf_edge ,
-        :tidal_delta ,
-        :upper ;
-    skos:prefLabel "Coastal delta lobe"@en ;
-    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
-    schema:status astatus:experimental ;
-.
-
-:coastal_fan_delta
-    a skos:Concept ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "currently under working group consultation"@en ;
-    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
-    skos:inScheme cs: ;
-    skos:narrower
-        :bayhead ,
-        :coastal_delta-front ,
-        :coastal_pro-delta ,
-        :lower ,
-        :shelf_edge ,
-        :tidal_delta ,
-        :upper ;
-    skos:prefLabel "Coastal fan delta"@en ;
-    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
-    schema:status astatus:experimental ;
-.
-
-:fluvial_fan_delta
-    a skos:Concept ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "currently under working group consultation"@en ;
-    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
-    skos:inScheme cs: ;
-    skos:prefLabel "Fluvial fan delta"@en ;
-    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
-    schema:status astatus:experimental ;
-.
-
-:sediment_trapped_bound
-    a skos:Concept ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "currently under working group consultation"@en ;
-    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
-    skos:inScheme cs: ;
-    skos:prefLabel "sediment trapped/bound"@en ;
-    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
-    schema:status astatus:experimental ;
-.
-
 :De_Geer_moraine
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
@@ -174,6 +92,30 @@ Cf. "abyss - hills" in Harris et al., (2014)."""@en ;
     skos:prefLabel "agglutinating"@en ;
     schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/BGU-Type_BGU-T"^^xsd:anyURI ;
     schema:status astatus:stable ;
+.
+
+:aggregation
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "currently under working group consultation"@en ;
+    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
+    skos:inScheme cs: ;
+    skos:prefLabel "aggregation"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:alluvial
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "currently under working group consultation"@en ;
+    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
+    skos:inScheme cs: ;
+    skos:prefLabel "alluvial"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/BGU-Type_BGU-T"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
 .
 
 :anchor_drag
@@ -632,6 +574,46 @@ Cf. "abyss - hills" in Harris et al., (2014)."""@en ;
     skos:prefLabel "closed lagoon"@en ;
     schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/BGU-Type_BGU-T"^^xsd:anyURI ;
     schema:status astatus:stable ;
+.
+
+:coastal_delta_lobe
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "currently under working group consultation"@en ;
+    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :bayhead ,
+        :coastal_delta-front ,
+        :coastal_pro-delta ,
+        :lower ,
+        :shelf_edge ,
+        :tidal_delta ,
+        :upper ;
+    skos:prefLabel "Coastal delta lobe"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
+:coastal_fan_delta
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "currently under working group consultation"@en ;
+    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :bayhead ,
+        :coastal_delta-front ,
+        :coastal_pro-delta ,
+        :lower ,
+        :shelf_edge ,
+        :tidal_delta ,
+        :upper ;
+    skos:prefLabel "Coastal fan delta"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
 .
 
 :coastal_fjord
@@ -1300,6 +1282,18 @@ Cf. COASTAL DELTA-FRONT"""@en ;
     schema:status astatus:stable ;
 .
 
+:fluvial_fan_delta
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "currently under working group consultation"@en ;
+    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
+    skos:inScheme cs: ;
+    skos:prefLabel "Fluvial fan delta"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
 :fluvial_fan_lobe
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
@@ -1624,21 +1618,6 @@ Cf. COASTAL PRO-DELTA"""@en ;
     skos:historyNote "2026-05: This Concept was updated in 2026 following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
     skos:inScheme cs: ;
     skos:prefLabel "gully"@en ;
-    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/BGU-Type_BGU-T"^^xsd:anyURI ;
-    schema:status astatus:stable ;
-.
-
-:guyot
-    a skos:Concept ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader :Solid_Earth_Setting ;
-    skos:definition "Flat-topped SEAMOUNTS or PLEATEAUS, usually former VOLCANOES, are formed by gradual subsidence through different stages. In many cases, they are capped by drowned atoll REEFS and pelagic sediment (modified after Harff et al., 2016)."@en ;
-    skos:historyNote "2026-05: This Concept was updated in 2026 following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
-    skos:inScheme cs: ;
-    skos:narrower
-        :non-volcanic ,
-        :volcanic ;
-    skos:prefLabel "guyot"@en ;
     schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/BGU-Type_BGU-T"^^xsd:anyURI ;
     schema:status astatus:stable ;
 .
@@ -3199,6 +3178,18 @@ Cf. "seamount" in Harris et al., (2014)."""@en ;
     schema:status astatus:stable ;
 .
 
+:sediment_trapped_bound
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "currently under working group consultation"@en ;
+    skos:historyNote "2026-05: This Concept was added in 2026 with status Experimental following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
+    skos:inScheme cs: ;
+    skos:prefLabel "sediment trapped/bound"@en ;
+    skos:topConceptOf cs: ;
+    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
+    schema:status astatus:experimental ;
+.
+
 :shear-margin_moraine
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
@@ -4083,6 +4074,21 @@ Cf. COASTAL DELTA"""@en ;
         :river_valley ;
     skos:prefLabel "Fluvial subaerial valley"@en ;
     schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/basic_geomorphic_unit_BGU"^^xsd:anyURI ;
+    schema:status astatus:stable ;
+.
+
+:guyot
+    a skos:Concept ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :Solid_Earth_Setting ;
+    skos:definition "Flat-topped SEAMOUNTS or PLEATEAUS, usually former VOLCANOES, are formed by gradual subsidence through different stages. In many cases, they are capped by drowned atoll REEFS and pelagic sediment (modified after Harff et al., 2016)."@en ;
+    skos:historyNote "2026-05: This Concept was updated in 2026 following revision and maintenance of the ISGM 2-part geomorphic classification scheme." ;
+    skos:inScheme cs: ;
+    skos:narrower
+        :non-volcanic ,
+        :volcanic ;
+    skos:prefLabel "guyot"@en ;
+    schema:citation "https://pid.geoscience.gov.au/def/voc/ga/SeabedGeomorphologyGeneral/BGU-Type_BGU-T"^^xsd:anyURI ;
     schema:status astatus:stable ;
 .
 
@@ -5182,7 +5188,13 @@ This is one of four linked ISGM-WG vocabularies. Definitions in this vocabulary 
         :Karst_Process ,
         :Marine_Setting ,
         :Mass_Movement_Process ,
-        :Solid_Earth_Setting ;
+        :Solid_Earth_Setting ,
+        :aggregation ,
+        :alluvial ,
+        :coastal_delta_lobe ,
+        :coastal_fan_delta ,
+        :fluvial_fan_delta ,
+        :sediment_trapped_bound ;
     skos:historyNote """2026-05: Removed BGU and BGU-T annotations from Concepts and instead added citation links for them.
 
 This vocabulary describes the glossary in Part 2 of the two-part seabed geomorphology classification scheme DOI: 10.5281/zenodo.7804019. This vocabulary was published in 2025 but following Phase Three of the Ocean Best Practice (OBP) approach, the concepts in 2026 have gone through revision and maintenance, which are reflected in this most recent update."""@en ;


### PR DESCRIPTION
Improve the hierarchy of Data Themes by:

* dual-listing subdisciplines of hydrology under it and geology subdisciplines
* nest geophysics and geochemistry under geology
* move data management under information management
* disentangle sample acquisition & management from data management